### PR TITLE
Remove conflicting file param to fix perceived issue with file paths …

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -183,7 +183,6 @@ module Jekyll
       def sass_embedded_config(data)
         {
           :data                => data,
-          :file                => filename,
           :indented_syntax     => syntax == :sass,
           :include_paths       => sass_load_paths,
           :output_style        => sass_style,


### PR DESCRIPTION
…in vanilla jekyll projects

Originally, the issue I was seeing was 

```bash
Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/style.scss':
                  No such file or directory @ rb_sysopen - /Users/spence/Developer/spenc.es/style.scss
                  ------------------------------------------------
    Jekyll 4.2.0   Please append `--trace` to the `build` command 
                   for any additional information or backtrace. 
                  ------------------------------------------------
```

After commenting out the `:file` parameter in `sass_embedded_config` the problem goes away, most likely because the `:data` parameter is sufficient? I’m not sure, not an expert in dart-sass, but that makes sense to me. 



